### PR TITLE
Companion PR to ControlSystems#346

### DIFF
--- a/src/genplots.jl
+++ b/src/genplots.jl
@@ -42,8 +42,8 @@ function getexamples()
     #Only siso for now
     nicholsgen() = nicholsplot(tf1,ws)
 
-    stepgen() = stepplot(sys, ts[end], ts[2]-ts[1], l=(:dash, 4))
-    impulsegen() = impulseplot(sys, ts[end], ts[2]-ts[1], l=:blue)
+    stepgen() = stepplot(sys, ts[end], l=(:dash, 4))
+    impulsegen() = impulseplot(sys, ts[end], l=:blue)
     L = lqr(sysss.A, sysss.B, [1 0; 0 1], [1 0; 0 1])
     lsimgen() = lsimplot(sysss, (x,i)->-L*x, ts, [1;2])
 


### PR DESCRIPTION
With https://github.com/JuliaControl/ControlSystems.jl/pull/346 we no longer need to supply `Ts` to these time-domain plots as they handle args in the same way as the underlying function, i.e., `stepplot` is called in the same way as `step`.
@mfalt 